### PR TITLE
Now getStream returns request object so it can be aborted from the app

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -143,6 +143,8 @@ Twitter.prototype.getStream = function(type, params, accessToken, accessTokenSec
 		});
 	});
 	req.end();
+
+	return req;
 }
 
 // Tweets


### PR DESCRIPTION
I had to do a tiny modification to the library because I was needing to end the streaming at any time. So, returning the request object, I can use the req.abort() method to finish it.
