### PR TITLE
changed erroneous second friends prototype to followers

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -255,7 +255,7 @@ Twitter.prototype.friends = function(type, params, accessToken, accessTokenSecre
 };
 
 // Followers (similiar to Friends)
-Twitter.prototype.friends = function(type, params, accessToken, accessTokenSecret, callback) {
+Twitter.prototype.followers = function(type, params, accessToken, accessTokenSecret, callback) {
 	var url = type.toLowerCase(); // ids or list
 
 	this.oa.get(baseUrl + "followers/" + url + ".json?" + querystring.stringify(params), accessToken, accessTokenSecret, function (error, data, response) {


### PR DESCRIPTION
Corrected a small typo - changed the prototype declaration in followers to be 'followers' instead of 'friends'. 

This allows you to make followers calls.
