### PR TITLE
Support new statuses lookup endpoint

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -173,6 +173,10 @@ Twitter.prototype.statuses = function(type, params, accessToken, accessTokenSecr
 			url = "show/"+params.id;
 			delete params.id;
 			break;
+		case "lookup":
+			url = "lookup";
+			method = "POST";
+			break;
 		case "destroy":
 			url = "destroy/"+params.id;
 			delete params.id;


### PR DESCRIPTION
Supports the new [statuses/lookup](https://dev.twitter.com/docs/api/1.1/get/statuses/lookup) endpoint as described in the Twitter API docs.
