### PR TITLE
Fixed bug of account/update_profile_image

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -405,7 +405,7 @@ Twitter.prototype.account = function(type, params, accessToken, accessTokenSecre
 			break;
 		case "update_profile_image":
 			this.updateProfileImage(params, accessToken, accessTokenSecret, callback);
-			break;
+			return;
 	}
 
 	if (method == "GET") {


### PR DESCRIPTION
When using "Twitter.prototype.account('update_profile_image', ....)", fire "this.oa.post(...)" requert in Twitter.prototype.account.

Called callback twice and "this.oa.post" is failed.

and fixed typo.
