### PR TITLE
Pass server response to stream endCallback

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -165,7 +165,7 @@ Twitter.prototype.getStream = function(type, params, accessToken, accessTokenSec
 			}
 		});
 		res.addListener("end", function() {
-			endCallback();
+			endCallback(res);
 		});
 	});
 	req.end();


### PR DESCRIPTION
This allows the endCallback to handle failure cases, like 'Exceeded streaming limit.'
