### PR TITLE
Add response object to getTimeline

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -107,7 +107,7 @@ Twitter.prototype.getTimeline = function(type, params, accessToken, accessTokenS
 			callback(error);
 		} else {
 			try {
-				callback(null, JSON.parse(data));
+				callback(null, JSON.parse(data), response);
 			} catch (e) {
 				callback(e, data, response);
 			}


### PR DESCRIPTION
Response object contains the important Twitter headers:
**X-Rate-Limit-Limit**: the rate limit ceiling for that given request
**X-Rate-Limit-Remaining**: the number of requests left for the 15 minute window
**X-Rate-Limit-Reset**: the remaining window before the rate limit resets in UTC epoch seconds

(https://dev.twitter.com/rest/public/rate-limiting)

Which can be used to rate limit the usage of the library. Without the response object there is no other way to obtain the twitter rate numbers.