### PR TITLE
response parameter in verifyCredentials callback

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -66,7 +66,7 @@ Twitter.prototype.verifyCredentials = function(accessToken, accessTokenSecret, p
 			} catch (e) {
 				callback(e, data, response);
 			}
-			callback(null, parsedData);
+			callback(null, parsedData, response);
 		}
 	});
 };


### PR DESCRIPTION
This parameter is not missing in any of the other methods.